### PR TITLE
fix: Remove trailing dots from config paths to prevent empty path error

### DIFF
--- a/src/main/java/net/zithium/deluxecoinflip/menu/inventories/CoinflipGUI.java
+++ b/src/main/java/net/zithium/deluxecoinflip/menu/inventories/CoinflipGUI.java
@@ -119,8 +119,8 @@ public class CoinflipGUI implements Listener {
                                 OfflinePlayer winner, OfflinePlayer loser, CoinflipGame game,
                                 Player targetPlayer, Location regionLoc, boolean isWinnerThread) {
 
-        ConfigurationSection animationConfig1 = plugin.getConfig().getConfigurationSection("coinflip-gui.animation.1.");
-        ConfigurationSection animationConfig2 = plugin.getConfig().getConfigurationSection("coinflip-gui.animation.2.");
+        ConfigurationSection animationConfig1 = plugin.getConfig().getConfigurationSection("coinflip-gui.animation.1");
+        ConfigurationSection animationConfig2 = plugin.getConfig().getConfigurationSection("coinflip-gui.animation.2");
 
         ItemStack firstAnimationItem = (animationConfig1 != null)
                 ? ItemStackBuilder.getItemStack(animationConfig1).build()

--- a/src/main/java/net/zithium/deluxecoinflip/utility/ItemStackBuilder.java
+++ b/src/main/java/net/zithium/deluxecoinflip/utility/ItemStackBuilder.java
@@ -94,6 +94,9 @@ public class ItemStackBuilder {
     }
 
     public ItemStackBuilder withFlags(ItemFlag... flags) {
+        if (ITEM_STACK.getType() == Material.AIR) {
+            return this;
+        }
         ItemMeta meta = ITEM_STACK.getItemMeta();
         meta.addItemFlags(flags);
         ITEM_STACK.setItemMeta(meta);
@@ -101,6 +104,9 @@ public class ItemStackBuilder {
     }
 
     public ItemStackBuilder withName(String name) {
+        if (ITEM_STACK.getType() == Material.AIR) {
+            return this;
+        }
         final ItemMeta meta = ITEM_STACK.getItemMeta();
         meta.setDisplayName(ColorUtil.color(name));
         ITEM_STACK.setItemMeta(meta);
@@ -123,6 +129,9 @@ public class ItemStackBuilder {
     }
 
     public ItemStackBuilder withLore(List<String> lore) {
+        if (ITEM_STACK.getType() == Material.AIR) {
+            return this;
+        }
         final ItemMeta meta = ITEM_STACK.getItemMeta();
         List<String> coloredLore = new ArrayList<>();
         for (String s : lore) {


### PR DESCRIPTION
- Added support for AIR material for people that want to make animation menu only show the head rotating

![image](https://github.com/user-attachments/assets/5ea63e0e-4ed8-41af-970b-156a0bf7ffc8)
