### PR TITLE
Decouples winner and loser GUIs to mitigate concurrency issues

### DIFF
--- a/src/main/java/net/zithium/deluxecoinflip/game/GameAnimationRunner.java
+++ b/src/main/java/net/zithium/deluxecoinflip/game/GameAnimationRunner.java
@@ -20,7 +20,7 @@ public class GameAnimationRunner {
         this.plugin = plugin;
     }
 
-    public void runAnimation(OfflinePlayer winner, OfflinePlayer loser, CoinflipGame game, Gui gui) {
+    public void runAnimation(OfflinePlayer winner, OfflinePlayer loser, CoinflipGame game, Gui winnerGui, Gui loserGui) {
         final WrappedScheduler scheduler = plugin.getScheduler();
 
         boolean isWinnerGamePlayer = winner.equals(game.getOfflinePlayer());
@@ -45,15 +45,19 @@ public class GameAnimationRunner {
 
         if (winnerPlayer != null) {
             scheduler.runTaskAtEntity(winnerPlayer, () -> {
-                gui.open(winnerPlayer);
-                plugin.getInventoryManager().getCoinflipGUI().startAnimation(scheduler, gui, winnerHead, loserHead, winner, loser, game, winnerPlayer, winnerPlayer.getLocation(), true);
+                winnerGui.open(winnerPlayer);
+                plugin.getInventoryManager().getCoinflipGUI().startAnimation(
+                    scheduler, winnerGui, winnerHead, loserHead,
+                    winner, loser, game, winnerPlayer, winnerPlayer.getLocation(), true);
             });
         }
 
         if (loserPlayer != null) {
             scheduler.runTaskAtEntity(loserPlayer, () -> {
-                gui.open(loserPlayer);
-                plugin.getInventoryManager().getCoinflipGUI().startAnimation(scheduler, gui, winnerHead, loserHead, winner, loser, game, loserPlayer, loserPlayer.getLocation(), false);
+                loserGui.open(loserPlayer);
+                plugin.getInventoryManager().getCoinflipGUI().startAnimation(
+                    scheduler, loserGui, winnerHead, loserHead,
+                    winner, loser, game, loserPlayer, loserPlayer.getLocation(), false);
             });
         }
     }

--- a/src/main/java/net/zithium/deluxecoinflip/menu/inventories/CoinflipGUI.java
+++ b/src/main/java/net/zithium/deluxecoinflip/menu/inventories/CoinflipGUI.java
@@ -83,10 +83,17 @@ public class CoinflipGUI implements Listener {
         OfflinePlayer winner = players.get(random.nextInt(players.size()));
         OfflinePlayer loser = (winner == creator) ? opponent : creator;
 
-        Gui gameGui = Gui.gui().rows(3).title(Component.text(coinflipGuiTitle)).create();
-        gameGui.disableAllInteractions();
+        // Mitigate concurrency issues with Folia
+        Gui winnerGui = createGameGui();
+        Gui loserGui = createGameGui();
 
-        this.gameAnimationRunner.runAnimation(winner, loser, game, gameGui);
+        this.gameAnimationRunner.runAnimation(winner, loser, game, winnerGui, loserGui);
+    }
+
+    private Gui createGameGui() {
+        Gui gui = Gui.gui().rows(3).title(Component.text(coinflipGuiTitle)).create();
+        gui.disableAllInteractions();
+        return gui;
     }
 
     public void startAnimation(WrappedScheduler scheduler, Gui gui, GuiItem winnerHead, GuiItem loserHead,


### PR DESCRIPTION
Resolved example exception:
```
[09:27:02] [Region Scheduler Thread #19/WARN]: [DeluxeCoinflip] Entity task for DeluxeCoinflip v2.10.3 generated an exception
java.util.ConcurrentModificationException: null
	at java.base/java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:1024) ~[?:?]
	at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1059) ~[?:?]
	at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1056) ~[?:?]
	at DeluxeCoinflip-2.10.3.jar/net.zithium.deluxecoinflip.libs.gui.guis.BaseGui.populateGui(BaseGui.java:979) ~[DeluxeCoinflip-2.10.3.jar:?]
	at DeluxeCoinflip-2.10.3.jar/net.zithium.deluxecoinflip.libs.gui.guis.BaseGui.open(BaseGui.java:435) ~[DeluxeCoinflip-2.10.3.jar:?]
	at DeluxeCoinflip-2.10.3.jar/net.zithium.deluxecoinflip.game.GameAnimationRunner.lambda$runAnimation$1(GameAnimationRunner.java:55) ~[DeluxeCoinflip-2.10.3.jar:?]
	at DeluxeCoinflip-2.10.3.jar/me.nahu.scheduler.wrapper.implementation.folia.FoliaWrappedScheduler.lambda$runTaskAtEntity$3(FoliaWrappedScheduler.java:109) ~[DeluxeCoinflip-2.10.3.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler$EntityScheduledTask.accept(FoliaEntityScheduler.java:168) ~[folia-1.21.4.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler$EntityScheduledTask.accept(FoliaEntityScheduler.java:115) ~[folia-1.21.4.jar:?]
	at io.papermc.paper.threadedregions.EntityScheduler.executeTick(EntityScheduler.java:181) ~[folia-1.21.4.jar:1.21.4-DEV-f69d1c9]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1658) ~[folia-1.21.4.jar:1.21.4-DEV-f69d1c9]
	at io.papermc.paper.threadedregions.TickRegions$ConcreteRegionTickHandle.tickRegion(TickRegions.java:407) ~[folia-1.21.4.jar:1.21.4-DEV-f69d1c9]
	at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:418) ~[folia-1.21.4.jar:1.21.4-DEV-f69d1c9]
	at ca.spottedleaf.concurrentutil.scheduler.SchedulerThreadPool$TickThreadRunner.run(SchedulerThreadPool.java:546) ~[concurrentutil-0.0.3.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1447) ~[?:?]